### PR TITLE
Add the option to pass URL session to ApiProvider

### DIFF
--- a/Sources/Microya/Core/ApiProvider.swift
+++ b/Sources/Microya/Core/ApiProvider.swift
@@ -22,15 +22,20 @@ open class ApiProvider<EndpointType: Endpoint> {
   /// The mocking behavior of the provider. Set this to receive mocked data in your tests. Use `nil` to make actual requests to your server (the default).
   public let mockingBehavior: MockingBehavior<EndpointType>?
 
+  /// The session used for making API requests.
+  public let urlSession: URLSession
+
   /// Initializes a new API provider with the given plugins applied to every request.
   public init(
     baseUrl: URL,
     plugins: [Plugin<EndpointType>] = [],
-    mockingBehavior: MockingBehavior<EndpointType>? = nil
+    mockingBehavior: MockingBehavior<EndpointType>? = nil,
+    urlSession: URLSession = .shared
   ) {
     self.baseUrl = baseUrl
     self.plugins = plugins
     self.mockingBehavior = mockingBehavior
+    self.urlSession = urlSession
   }
 
   /// Returns a publisher which performs a request to the server when new values are requested.
@@ -98,7 +103,7 @@ open class ApiProvider<EndpointType: Endpoint> {
     }
     else {
       // this is the main logic, making the actual call
-      return URLSession.shared.dataTaskPublisher(for: request)
+      return urlSession.dataTaskPublisher(for: request)
         .mapError { (urlError) -> ApiError<EndpointType.ClientErrorType> in
           urlSessionResult = (data: nil, response: nil, error: urlError)
           let apiError: ApiError<EndpointType.ClientErrorType> = self.mapToClientErrorType(error: urlError)
@@ -207,7 +212,7 @@ open class ApiProvider<EndpointType: Endpoint> {
     else {
       // this is the main logic, making the actual call
       do {
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
         return handleResponse(data: data, response: response, error: nil)
       }
       catch {
@@ -299,7 +304,7 @@ open class ApiProvider<EndpointType: Endpoint> {
     }
     else {
       // this is the main logic, making the actual call
-      URLSession.shared.dataTask(with: request, completionHandler: handleDataTaskCompletion).resume()
+      urlSession.dataTask(with: request, completionHandler: handleDataTaskCompletion).resume()
     }
   }
 


### PR DESCRIPTION
This PR aims at adding more flexibility to ApiProvider by passing **URLSession** object to it. Currently, the shared object is used, which limits the functionality of the `ApiProvide` if, for example, consumer needs to pass their `URLSession` with its own `URLSessionConfiguration`.

## Proposed Changes
  - Adding a new parameter to the initializer call `urlSession` to pass the URLSession object.
  - This new parameter will have a default value `shared`.